### PR TITLE
Lowercase lettering causing discovery issues on Linux OS's.

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -9,7 +9,7 @@ class AppController extends BaseController {
 	public function initialize() {
 		parent::initialize();
 
-		$this->loadComponent('FileManager.Filesystem');
+		$this->loadComponent('FileManager.FileSystem');
 		$this->viewBuilder()->layout('FileManager.default');
 	}
 }

--- a/src/Controller/Component/FileSystemComponent.php
+++ b/src/Controller/Component/FileSystemComponent.php
@@ -7,7 +7,7 @@ use Cake\Controller\ComponentRegistry;
 use League\Flysystem\Adapter\Local as LocalAdapter;
 use League\Flysystem\Filesystem;
 
-class FilesystemComponent extends Component {
+class FileSystemComponent extends Component {
 
    /**
      * Default configuration.


### PR DESCRIPTION
The lowercasing on the component naming was causing Linux operating systems to not discover the file, this has been ammended  
	modified:   src/Controller/AppController.php
 	modified:   src/Controller/Component/FileSystemComponent.php